### PR TITLE
Smart choose the Mesos libs path

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,11 @@ AC_ARG_WITH([mesos_build_dir],
 
 if test -d "$mesos"; then
   MESOS_CPPFLAGS="-I${mesos}/include"
-  MESOS_LDFLAGS="-L${mesos}/lib64 -lmesos -lglog -lprotobuf"
+  if test -d "${mesos}/lib"; then
+    MESOS_LDFLAGS="-L${mesos}/lib -lmesos -lglog -lprotobuf"
+  else
+    MESOS_LDFLAGS="-L${mesos}/lib64 -lmesos -lglog -lprotobuf"
+  fi
 else
 
   if test -d "$mesos_root"; then


### PR DESCRIPTION
On Ubuntu, the Mesos libs will be install to $prefix/lib by default.
So add an if condition to choose which path is the right one.